### PR TITLE
Ensure code coverage analysis is provided.

### DIFF
--- a/shelib/build.gradle
+++ b/shelib/build.gradle
@@ -1,27 +1,24 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-
-
-
+    compileSdkVersion 27
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
-
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
     }
 
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit's raison d'etre is to ensure that both the sample app and the library provide code coverage statistics and a report for each.  The report clearly shows that we are starting from the grounded perch of 0% code coverage, i.e. no tests ensure that any lines of production code are executed, a great position to be in for a TDD developer.

<h1>File changes:</h1>

modified:   shelib/build.gradle

- Summary: ensure that the Sdk is at the current level; turn on code coverage analysis in the Android Gradle plugin.